### PR TITLE
IE8 throws an "Unspecified error."

### DIFF
--- a/public/EventSource.js
+++ b/public/EventSource.js
@@ -43,7 +43,7 @@ var EventSource = function (url) {
     
       xhr.timeout = 50000;
       xhr.onreadystatechange = function () {
-        if ((this.readyState == 3 || this.readyState == 4) && this.status == 200) {
+        if (this.readyState == 3 || (this.readyState == 4 && this.status == 200)){
           // on success
           if (eventsource.readyState == eventsource.CONNECTING) {
             eventsource.readyState = eventsource.OPEN;


### PR DESCRIPTION
When receiving an event, the code tries to read `xhr.status` whatever the `ready_state` is either `3` or `4`.

On IE8, accessing `status` on xmlhttprequests with `ready_state` = 3 raises "Unspecified error".
